### PR TITLE
Assorted fixes, including Ansible 2.0 compatibility

### DIFF
--- a/pacemaker
+++ b/pacemaker
@@ -459,7 +459,7 @@ def main():
     if args[0] == "commit":
         rc, out, err = module.run_command(["crm", "configure", "commit"])
         if rc:
-            module.fail_json(rc=256, msg="crm command failed")
+            module.fail_json(rc=256, msg="crm command failed", out=out, err=err)
         module.exit_json(args=args, changed=True)
 
     parser = CIBParser(module)
@@ -468,14 +468,16 @@ def main():
     crm_args = ["crm", "configure", "show"]
     rc, out, err = module.run_command(crm_args)
     if rc:
-        module.fail_json(rc=256, msg="crm command failed")
+        module.fail_json(rc=256, msg="crm configure show failed", out=out, err=err)
 
     is_same = None
+    old_cib = None
     for cur in parser.parse_cibs(out.splitlines()):
         if new.command != cur.command:
             continue
         if new.id != cur.id:
             continue
+        old_cib = cur.cib
         is_same = new.is_same(cur)
         break
 
@@ -510,7 +512,7 @@ def main():
             #FIXME: Re-enable error messages.
             #module.fail_json(rc=256, msg="crm command failed \n%s"%err)
 
-    module.exit_json(args=args, changed=True)
+    module.exit_json(args=args, old=old_cib, new=new.cib, changed=True)
 
 
 # import module snippets

--- a/pacemaker
+++ b/pacemaker
@@ -243,18 +243,13 @@ class LocationParser(BaseParser):
     id_name = "id"
 
     def parse(self, args):
+        argscopy = list(args)
         ret = dict(
             command=args.pop(0),
             id=args.pop(0),
             rsc=args.pop(0),
             )
-        arg = args.pop(0)
-        if arg != "rules":
-            ret["score"] = args.pop(0)
-            ret["node"] = args.pop(0)
-            return ret
-        else:
-            ret["rules"] = []
+        ret["rules"] = []
 
         newrule = None
         while (args):
@@ -271,22 +266,23 @@ class LocationParser(BaseParser):
                         self.module.fail_json(
                             rc=258,
                             msg="no value in key=value option (key=%s)" % key)
-                    newargs[key] = value
+                    newrule[key] = value
                     arg = args.pop(0)
                 if arg.endswith(":"):
-                    newargs["score"] = arg
+                    newrule["score"] = arg
                 else:
                     self.module.fail_json(
                         rc=258,
                         msg="no score in rule for location (id=%s)" % ret["id"])
 
             elif newrule is not None:
-                newrule["expression"].append(args)
+                newrule["expression"].append(arg)
 
             else:
                 self.module.fail_json(
                     rc=258,
-                    msg="no rule for location (id=%s)" % ret["id"])
+                    msg="no rule for location (id=%s)" % ret["id"],
+                    args=argscopy)
         if newrule:
             ret["rules"].append(newrule)
 

--- a/pacemaker
+++ b/pacemaker
@@ -105,6 +105,10 @@ class PrimitiveParser(BaseParser):
             rsc=args.pop(0),
             type=args.pop(0),
             )
+
+        if ':' not in ret['type']:
+            ret['type'] = 'ocf:heartbeat:' + ret['type']
+
         mode = None
         while (len(args) > 0):
             arg = args.pop(0)
@@ -126,6 +130,9 @@ class PrimitiveParser(BaseParser):
                 self.module.fail_json(
                     rc=258,
                     msg="no value in key=value option (key=%s)" % key)
+
+            if value.startswith('"') and value.endswith('"'):
+                value = value[1:-1]
 
             if mode not in ret:
                 ret[mode] = {}

--- a/pacemaker
+++ b/pacemaker
@@ -444,13 +444,18 @@ class CIBParser(object):
 
 def main():
 
-    # the command module is the one ansible module that does not take key=value args
-    # hence don't copy this one if you are looking to build others!
-    module = PacemakerModule(argument_spec=dict())
+    module = AnsibleModule(
+        argument_spec={
+            'resource': dict(required=True),
+            'state': dict(default='present', choices=['present', 'absent']),
+            'commit': dict(default=True, type='bool', choices=BOOLEANS),
+        },
+        supports_check_mode=True
+    )
 
     state = module.params['state']
     need_commit = module.params['commit']
-    args = splitter(module.params['args'])
+    args = splitter(module.params['resource'])
     changed = False
 
     if len(args) == 0:
@@ -505,54 +510,16 @@ def main():
         crm_config_commands.append(["configure"] + args)
     if need_commit:
         crm_config_commands.append(["configure", "commit"])
-    for command in crm_config_commands:
-        rc, out, err = module.run_command(["crm", "-F"] + command)
-        if rc:
-            module.fail_json(rc=256, msg="crm command failed")
-            #FIXME: Re-enable error messages.
-            #module.fail_json(rc=256, msg="crm command failed \n%s"%err)
+    if not module.check_mode:
+        for command in crm_config_commands:
+            rc, out, err = module.run_command(["crm", "-F", "-w"] + command)
+            if rc:
+                module.fail_json(rc=256, msg="crm -F -w %s failed" % ' '.join(command), out=out, err=err)
 
     module.exit_json(args=args, old=old_cib, new=new.cib, changed=True)
 
 
 # import module snippets
 from ansible.module_utils.basic import *
-
-# only the command module should ever need to do this
-# everything else should be simple key=value
-
-class PacemakerModule(AnsibleModule):
-
-    def _handle_aliases(self):
-        return {}
-
-    def _check_invalid_arguments(self):
-        pass
-
-    def _load_params(self):
-        ''' read the input and return a dictionary and the arguments string '''
-        args = MODULE_ARGS
-        params = {}
-
-        params["state"] = "present"
-        params["commit"] = True
-        r = re.compile(r'(^|\s)(state)=(?P<quote>[\'"])?(.*?)(?(quote)(?<!\\)(?P=quote))((?<!\\)(?=\s)|$)')
-        for m in r.finditer(args):
-            v = m.group(4).replace("\\", "")
-            if m.group(2) == "state":
-                if v not in ["present", "absent"]:
-                    self.fail_json(
-                            rc=256, msg="state= is either present or absent")
-                params['state'] = v
-            if m.group(2) == "commit":
-                if v not in ["yes", "no"]:
-                    self.fail_json(
-                            rc=256, msg="commit= is either yes or no")
-                if v == 'yes':
-                    params['commit'] = True
-        args = r.sub("", args)
-
-        params["args"] = args.strip()
-        return (params, params["args"])
 
 main()


### PR DESCRIPTION
The highlight (apart from a couple of fixes regarding `crm` output parsing) is Ansible 2.0 compatibility. Unfortunately in 2.0 modules can no longer use free-form parameters (only a few hardcoded whitelisted ones can) so this breaks playbook compatibility (must use resource: "whatever" as the parameter).

Works for me in production with following resource types:
- primitive
- clone
- ms
- location
- colocation
- order